### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,10 +6,10 @@ module(
 
 
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
-bazel_dep(name = "rules_cc", version = "0.2.14")
-bazel_dep(name = "zlib", version = "1.3.1.bcr.7")
-bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)
-bazel_dep(name = "rules_m4", version = "0.3")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "zlib", version = "1.3.2")
+bazel_dep(name = "platforms", version = "1.1.0", dev_dependency = True)
+bazel_dep(name = "rules_m4", version = "0.3.bcr.1")
 
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -26,7 +26,7 @@ http_archive(
 
 # Based on:
 # https://github.com/f0rmiga/gcc-toolchain/blob/main/examples/bzlmod/MODULE.bazel
-bazel_dep(name = "gcc_toolchain", version = "0.9.0", dev_dependency = True)
+bazel_dep(name = "gcc_toolchain", version = "0.10.0", dev_dependency = True)
 gcc_toolchains = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
 [
     [


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_cc: 0.2.14 -> 0.2.19
* zlib: 1.3.1.bcr.7 -> 1.3.2
* platforms: 1.0.0 -> 1.1.0
* rules_m4: 0.3 -> 0.3.bcr.1
* gcc_toolchain: 0.9.0 -> 0.10.0